### PR TITLE
Add semicolon to better support minification of variable declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ module.exports = function(params) {
                 file.path = replaceFilename(file.path, params.filename, params.useAsVariable)
 
                 var exVars = (params.useAsVariable) ? "var " + params.filename + "=" : ""
-                file.contents = new Buffer(exVars + JSON.stringify(outputJson));
+                file.contents = new Buffer(exVars + JSON.stringify(outputJson) + ";");
             }
         }
 


### PR DESCRIPTION
If the variable produced is included in a minified/uglified bundle, the missing semicolon at the end can cause syntax errors in the resulting file.